### PR TITLE
Precompile Tailwind styles and improve accessibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,57 +6,49 @@
     <!-- SEO Optimization: Updated Title and added Meta Description -->
     <title>Cloud Migration Services to AWS, Azure, GCP - Email & DNS Migration Partner</title>
     <meta name="description" content="Expert cloud migration services for SMBs. We specialize in seamless on-premise migrations to AWS, Azure, and GCP, including email migrations to Google Workspace and Microsoft 365.">
-
-    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="canonical" href="https://moliseit.com/">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://moliseit.com/">
+    <meta property="og:title" content="Cloud Migration Services to AWS, Azure, GCP - Email &amp; DNS Migration Partner">
+    <meta property="og:description" content="Expert cloud migration services for SMBs. We specialize in seamless on-premise migrations to AWS, Azure, and GCP, including email migrations to Google Workspace and Microsoft 365.">
+    <meta property="og:image" content="https://moliseit.com/public/favicon.svg">
+    <meta property="og:site_name" content="Molise IT">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Cloud Migration Services to AWS, Azure, GCP - Email &amp; DNS Migration Partner">
+    <meta name="twitter:description" content="Expert cloud migration services for SMBs. We specialize in seamless on-premise migrations to AWS, Azure, and GCP, including email migrations to Google Workspace and Microsoft 365.">
+    <meta name="twitter:image" content="https://moliseit.com/public/favicon.svg">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <link rel="icon" type="image/svg+xml" href="public/favicon.svg">
-    <style>
-        body {
-            font-family: 'Inter', sans-serif;
-        }
-        .section-heading {
-            font-weight: 600;
-            color: #1a202c; /* A dark gray for contrast */
-        }
-        .square-hover {
-            transition: transform 0.35s ease, box-shadow 0.35s ease;
-        }
-        .square-hover:hover {
-            transform: translateY(-6px) scale(1.03);
-            box-shadow: 0 24px 45px -20px rgba(30, 64, 175, 0.45);
-        }
-        .logo-hover {
-            transition: transform 0.35s ease, filter 0.35s ease;
-        }
-        .logo-hover:hover {
-            transform: translateY(-4px) scale(1.06) rotate(-2deg);
-            filter: drop-shadow(0 12px 24px rgba(30, 64, 175, 0.35));
-        }
-        .flag-hover {
-            transition: transform 0.35s ease, box-shadow 0.35s ease;
-        }
-        .flag-hover:hover {
-            transform: translateY(-6px) scale(1.05) rotate(1.5deg);
-            box-shadow: 0 16px 32px -18px rgba(15, 23, 42, 0.55);
-        }
-    </style>
+    <link rel="stylesheet" href="public/css/tailwind.min.css" integrity="sha384-KOgYjtHA0zht0JIOiMcvPYg+E/uFaoCOQ7ZJ2TaHGVrqxy2ifxhrejZEsUeynr+v" crossorigin="anonymous">
 </head>
 <body class="bg-gray-50 text-gray-800">
+    <a class="skip-link" href="#main-content">Skip to main content</a>
 
     <!-- Header & Hero Section -->
     <header class="bg-gradient-to-r from-blue-600 to-blue-800 text-white py-12 px-6 sm:px-12 md:px-24 relative">
         <div class="absolute top-4 left-4 sm:top-6 sm:left-6">
-            <img src="public/favicon.svg" alt="Molise IT logo" class="h-12 w-12 rounded-xl shadow-md logo-hover">
+            <img src="public/favicon.svg" alt="Molise IT logo" class="h-12 w-12 rounded-xl shadow-md logo-hover" width="64" height="64">
         </div>
         <div class="absolute top-4 right-4 sm:top-6 sm:right-6 flex items-center gap-3">
             <a href="https://github.com/your-profile" target="_blank" rel="noopener" class="bg-white/20 hover:bg-white/30 transition-colors rounded-full p-2" aria-label="Visit our GitHub">
-                <img src="public/logos/github.svg" alt="GitHub logo" class="h-6 w-6 logo-hover">
+                <img src="public/logos/github.svg" alt="GitHub logo" class="h-6 w-6 logo-hover" width="2500" height="2432" loading="lazy">
             </a>
             <a href="https://slack.com/your-workspace" target="_blank" rel="noopener" class="bg-white/20 hover:bg-white/30 transition-colors rounded-full p-2" aria-label="Join us on Slack">
-                <img src="public/logos/slack.svg" alt="Slack logo" class="h-6 w-6 logo-hover">
+                <img src="public/logos/slack.svg" alt="Slack logo" class="h-6 w-6 logo-hover" width="2447.6" height="2452.5" loading="lazy">
             </a>
+        </div>
+        <div class="max-w-4xl mx-auto">
+            <nav class="header-nav" aria-label="Primary">
+                <ul>
+                    <li><a href="#services">Services</a></li>
+                    <li><a href="#about">About</a></li>
+                    <li><a href="#pci-dss">PCI DSS</a></li>
+                    <li><a href="#regions">Regions</a></li>
+                    <li><a href="#contact">Contact</a></li>
+                </ul>
+            </nav>
         </div>
         <div class="max-w-4xl mx-auto text-center">
             <h1 class="text-4xl sm:text-5xl md:text-6xl font-bold leading-tight mb-4">Migrate Your Business to the Cloud, Seamlessly.</h1>
@@ -69,7 +61,7 @@
         </div>
     </header>
 
-    <main class="container mx-auto px-6 sm:px-12 md:px-24 py-16">
+    <main id="main-content" class="container mx-auto px-6 sm:px-12 md:px-24 py-16">
 
         <!-- Services Section with Logos -->
         <section id="services" class="mb-20">
@@ -81,22 +73,22 @@
             </div>
             <div class="grid gap-8 sm:grid-cols-2 xl:grid-cols-4">
                 <div class="flex flex-col items-center bg-white p-6 rounded-2xl shadow-md border border-blue-100 square-hover">
-                    <img src="public/logos/aws.svg" alt="Amazon Web Services logo" class="h-16 w-auto mb-4 logo-hover">
+                    <img src="public/logos/aws.svg" alt="Amazon Web Services logo" class="h-16 w-auto mb-4 logo-hover" width="2500" height="1465" loading="lazy">
                     <h3 class="font-semibold text-lg text-blue-900">AWS Cloud</h3>
                     <p class="text-sm text-gray-500 text-center">Infrastructure migrations, modernization, and landing zones.</p>
                 </div>
                 <div class="flex flex-col items-center bg-white p-6 rounded-2xl shadow-md border border-blue-100 square-hover">
-                    <img src="public/logos/azure.svg" alt="Microsoft Azure logo" class="h-16 w-auto mb-4 logo-hover">
+                    <img src="public/logos/azure.svg" alt="Microsoft Azure logo" class="h-16 w-auto mb-4 logo-hover" width="2500" height="2359" loading="lazy">
                     <h3 class="font-semibold text-lg text-blue-900">Microsoft Azure</h3>
                     <p class="text-sm text-gray-500 text-center">Hybrid integrations, governance, and workload migrations.</p>
                 </div>
                 <div class="flex flex-col items-center bg-white p-6 rounded-2xl shadow-md border border-blue-100 square-hover">
-                    <img src="public/logos/365.svg" alt="Microsoft 365 logo" class="h-16 w-auto mb-4 logo-hover">
+                    <img src="public/logos/365.svg" alt="Microsoft 365 logo" class="h-16 w-auto mb-4 logo-hover" width="2215" height="2500" loading="lazy">
                     <h3 class="font-semibold text-lg text-blue-900">Microsoft 365</h3>
                     <p class="text-sm text-gray-500 text-center">Tenant-to-tenant moves, security hardening, and productivity suites.</p>
                 </div>
                 <div class="flex flex-col items-center bg-white p-6 rounded-2xl shadow-md border border-blue-100 square-hover">
-                    <img src="public/logos/google-workspace.svg" alt="Google Workspace logo" class="h-16 w-auto mb-4 logo-hover">
+                    <img src="public/logos/google-workspace.svg" alt="Google Workspace logo" class="h-16 w-auto mb-4 logo-hover" width="2500" height="309" loading="lazy">
                     <h3 class="font-semibold text-lg text-blue-900">Google Workspace</h3>
                     <p class="text-sm text-gray-500 text-center">Email, collaboration, and identity migrations with minimal downtime.</p>
                 </div>
@@ -105,91 +97,91 @@
                 <h3 class="text-2xl font-semibold text-blue-800 text-center mb-6">Other supported platforms &amp; technologies</h3>
                 <div class="grid gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
                     <div class="flex flex-col items-center bg-white p-5 rounded-2xl shadow-md square-hover">
-                        <img src="public/logos/gcp.svg" alt="Google Cloud Platform logo" class="h-12 w-auto mb-3 logo-hover">
+                        <img src="public/logos/gcp.svg" alt="Google Cloud Platform logo" class="h-12 w-auto mb-3 logo-hover" width="2385.7" height="1919.9" loading="lazy">
                         <span class="text-sm font-medium text-gray-700 text-center">Google Cloud Platform</span>
                     </div>
                     <div class="flex flex-col items-center bg-white p-5 rounded-2xl shadow-md square-hover">
-                        <img src="public/logos/cloudflare.svg" alt="Cloudflare logo" class="h-12 w-auto mb-3 logo-hover">
+                        <img src="public/logos/cloudflare.svg" alt="Cloudflare logo" class="h-12 w-auto mb-3 logo-hover" width="1889.4" height="627" loading="lazy">
                         <span class="text-sm font-medium text-gray-700 text-center">Cloudflare</span>
                     </div>
                     <div class="flex flex-col items-center bg-white p-5 rounded-2xl shadow-md square-hover">
-                        <img src="public/logos/terraform.svg" alt="Terraform logo" class="h-12 w-auto mb-3 logo-hover">
+                        <img src="public/logos/terraform.svg" alt="Terraform logo" class="h-12 w-auto mb-3 logo-hover" width="128" height="128" loading="lazy">
                         <span class="text-sm font-medium text-gray-700 text-center">Terraform</span>
                     </div>
                     <div class="flex flex-col items-center bg-white p-5 rounded-2xl shadow-md square-hover">
-                        <img src="public/logos/digitalocean.svg" alt="DigitalOcean logo" class="h-12 w-auto mb-3 logo-hover">
+                        <img src="public/logos/digitalocean.svg" alt="DigitalOcean logo" class="h-12 w-auto mb-3 logo-hover" width="2500" height="422" loading="lazy">
                         <span class="text-sm font-medium text-gray-700 text-center">DigitalOcean</span>
                     </div>
                     <div class="flex flex-col items-center bg-white p-5 rounded-2xl shadow-md square-hover">
-                        <img src="public/logos/akamai.svg" alt="Akamai logo" class="h-12 w-auto mb-3 logo-hover">
+                        <img src="public/logos/akamai.svg" alt="Akamai logo" class="h-12 w-auto mb-3 logo-hover" width="2500" height="1021" loading="lazy">
                         <span class="text-sm font-medium text-gray-700 text-center">Akamai CDN &amp; Edge</span>
                     </div>
                     <div class="flex flex-col items-center bg-white p-5 rounded-2xl shadow-md square-hover">
-                        <img src="public/logos/linode.svg" alt="Linode logo" class="h-12 w-auto mb-3 logo-hover">
+                        <img src="public/logos/linode.svg" alt="Linode logo" class="h-12 w-auto mb-3 logo-hover" width="2500" height="978" loading="lazy">
                         <span class="text-sm font-medium text-gray-700 text-center">Linode</span>
                     </div>
                     <div class="flex flex-col items-center bg-white p-5 rounded-2xl shadow-md square-hover">
-                        <img src="public/logos/elasticsearch.svg" alt="Elasticsearch logo" class="h-12 w-auto mb-3 logo-hover">
+                        <img src="public/logos/elasticsearch.svg" alt="Elasticsearch logo" class="h-12 w-auto mb-3 logo-hover" width="2500" height="2500" loading="lazy">
                         <span class="text-sm font-medium text-gray-700 text-center">Elasticsearch</span>
                     </div>
                     <div class="flex flex-col items-center bg-white p-5 rounded-2xl shadow-md square-hover">
-                        <img src="public/logos/datadog.svg" alt="Datadog logo" class="h-12 w-auto mb-3 logo-hover">
+                        <img src="public/logos/datadog.svg" alt="Datadog logo" class="h-12 w-auto mb-3 logo-hover" width="128" height="128" loading="lazy">
                         <span class="text-sm font-medium text-gray-700 text-center">Datadog</span>
                     </div>
                     <div class="flex flex-col items-center bg-white p-5 rounded-2xl shadow-md square-hover">
-                        <img src="public/logos/sharepoint.svg" alt="SharePoint logo" class="h-12 w-auto mb-3 logo-hover">
+                        <img src="public/logos/sharepoint.svg" alt="SharePoint logo" class="h-12 w-auto mb-3 logo-hover" width="2500" height="2480" loading="lazy">
                         <span class="text-sm font-medium text-gray-700 text-center">SharePoint Online</span>
                     </div>
                     <div class="flex flex-col items-center bg-white p-5 rounded-2xl shadow-md square-hover">
-                        <img src="public/logos/teams.svg" alt="Microsoft Teams logo" class="h-12 w-auto mb-3 logo-hover">
+                        <img src="public/logos/teams.svg" alt="Microsoft Teams logo" class="h-12 w-auto mb-3 logo-hover" width="2500" height="2458" loading="lazy">
                         <span class="text-sm font-medium text-gray-700 text-center">Microsoft Teams</span>
                     </div>
                     <div class="flex flex-col items-center bg-white p-5 rounded-2xl shadow-md square-hover">
-                        <img src="public/logos/slack.svg" alt="Slack logo" class="h-12 w-auto mb-3 logo-hover">
+                        <img src="public/logos/slack.svg" alt="Slack logo" class="h-12 w-auto mb-3 logo-hover" width="2447.6" height="2452.5" loading="lazy">
                         <span class="text-sm font-medium text-gray-700 text-center">Slack</span>
                     </div>
                     <div class="flex flex-col items-center bg-white p-5 rounded-2xl shadow-md square-hover">
-                        <img src="public/logos/notion.svg" alt="Notion logo" class="h-12 w-auto mb-3 logo-hover">
+                        <img src="public/logos/notion.svg" alt="Notion logo" class="h-12 w-auto mb-3 logo-hover" width="128" height="128" loading="lazy">
                         <span class="text-sm font-medium text-gray-700 text-center">Notion</span>
                     </div>
                     <div class="flex flex-col items-center bg-white p-5 rounded-2xl shadow-md square-hover">
-                        <img src="public/logos/linear.svg" alt="Linear logo" class="h-12 w-auto mb-3 logo-hover">
+                        <img src="public/logos/linear.svg" alt="Linear logo" class="h-12 w-auto mb-3 logo-hover" width="128" height="128" loading="lazy">
                         <span class="text-sm font-medium text-gray-700 text-center">Linear App</span>
                     </div>
                     <div class="flex flex-col items-center bg-white p-5 rounded-2xl shadow-md square-hover">
-                        <img src="public/logos/github.svg" alt="GitHub logo" class="h-12 w-auto mb-3 logo-hover">
+                        <img src="public/logos/github.svg" alt="GitHub logo" class="h-12 w-auto mb-3 logo-hover" width="2500" height="2432" loading="lazy">
                         <span class="text-sm font-medium text-gray-700 text-center">GitHub</span>
                     </div>
                     <div class="flex flex-col items-center bg-white p-5 rounded-2xl shadow-md square-hover">
-                        <img src="public/logos/gitlab.svg" alt="GitLab logo" class="h-12 w-auto mb-3 logo-hover">
+                        <img src="public/logos/gitlab.svg" alt="GitLab logo" class="h-12 w-auto mb-3 logo-hover" width="2500" height="2305" loading="lazy">
                         <span class="text-sm font-medium text-gray-700 text-center">GitLab</span>
                     </div>
                     <div class="flex flex-col items-center bg-white p-5 rounded-2xl shadow-md square-hover">
-                        <img src="public/logos/openai.svg" alt="OpenAI logo" class="h-12 w-auto mb-3 logo-hover">
+                        <img src="public/logos/openai.svg" alt="OpenAI logo" class="h-12 w-auto mb-3 logo-hover" width="128" height="128" loading="lazy">
                         <span class="text-sm font-medium text-gray-700 text-center">OpenAI ChatGPT</span>
                     </div>
                     <div class="flex flex-col items-center bg-white p-5 rounded-2xl shadow-md square-hover">
-                        <img src="public/logos/gemini.svg" alt="Gemini logo" class="h-12 w-auto mb-3 logo-hover">
+                        <img src="public/logos/gemini.svg" alt="Gemini logo" class="h-12 w-auto mb-3 logo-hover" width="64" height="64" loading="lazy">
                         <span class="text-sm font-medium text-gray-700 text-center">Google Gemini</span>
                     </div>
                     <div class="flex flex-col items-center bg-white p-5 rounded-2xl shadow-md square-hover">
-                        <img src="public/logos/godaddy.svg" alt="GoDaddy logo" class="h-12 w-auto mb-3 logo-hover">
+                        <img src="public/logos/godaddy.svg" alt="GoDaddy logo" class="h-12 w-auto mb-3 logo-hover" width="3732" height="2500" loading="lazy">
                         <span class="text-sm font-medium text-gray-700 text-center">GoDaddy</span>
                     </div>
                     <div class="flex flex-col items-center bg-white p-5 rounded-2xl shadow-md square-hover">
-                        <img src="public/logos/kubernetes.svg" alt="Kubernetes logo" class="h-12 w-auto mb-3 logo-hover">
+                        <img src="public/logos/kubernetes.svg" alt="Kubernetes logo" class="h-12 w-auto mb-3 logo-hover" width="2500" height="2432" loading="lazy">
                         <span class="text-sm font-medium text-gray-700 text-center">Kubernetes</span>
                     </div>
                     <div class="flex flex-col items-center bg-white p-5 rounded-2xl shadow-md square-hover">
-                        <img src="public/logos/linux.svg" alt="Linux logo" class="h-12 w-auto mb-3 logo-hover">
+                        <img src="public/logos/linux.svg" alt="Linux logo" class="h-12 w-auto mb-3 logo-hover" width="2500" height="2500" loading="lazy">
                         <span class="text-sm font-medium text-gray-700 text-center">Linux</span>
                     </div>
                     <div class="flex flex-col items-center bg-white p-5 rounded-2xl shadow-md square-hover">
-                        <img src="public/logos/windows.svg" alt="Windows Server logo" class="h-12 w-auto mb-3 logo-hover">
+                        <img src="public/logos/windows.svg" alt="Windows Server logo" class="h-12 w-auto mb-3 logo-hover" width="2490" height="2500" loading="lazy">
                         <span class="text-sm font-medium text-gray-700 text-center">Windows Server</span>
                     </div>
                     <div class="flex flex-col items-center bg-white p-5 rounded-2xl shadow-md square-hover">
-                        <img src="public/logos/vmware.svg" alt="VMware logo" class="h-12 w-auto mb-3 logo-hover">
+                        <img src="public/logos/vmware.svg" alt="VMware logo" class="h-12 w-auto mb-3 logo-hover" width="678" height="103.4" loading="lazy">
                         <span class="text-sm font-medium text-gray-700 text-center">VMware</span>
                     </div>
                 </div>
@@ -214,7 +206,7 @@
         <!-- PCI DSS Section -->
         <section id="pci-dss" class="mb-20 text-center bg-blue-100 p-8 sm:p-12 md:p-16 rounded-3xl shadow-lg">
             <div class="flex justify-center mb-6">
-                <img src="public/logos/pci.svg" alt="PCI DSS logo" class="h-20 w-auto logo-hover">
+                <img src="public/logos/pci.svg" alt="PCI DSS logo" class="h-20 w-auto logo-hover" width="3500" height="1060" loading="lazy">
             </div>
             <h2 class="text-3xl sm:text-4xl section-heading mb-6">PCI DSS Compliance Expertise</h2>
             <p class="text-gray-700 leading-relaxed text-lg mb-4">
@@ -245,23 +237,23 @@
             </p>
             <div class="flex flex-wrap justify-center items-center gap-8">
                 <div class="flex flex-col items-center">
-                    <img src="public/flags/us.svg" alt="United States flag" class="h-14 w-auto rounded-lg shadow-md mb-2 flag-hover">
+                    <img src="public/flags/us.svg" alt="United States flag" class="h-14 w-auto rounded-lg shadow-md mb-2 flag-hover" width="512" height="512" loading="lazy">
                     <span class="text-gray-600">United States</span>
                 </div>
                 <div class="flex flex-col items-center">
-                    <img src="public/flags/ca.svg" alt="Canada flag" class="h-14 w-auto rounded-lg shadow-md mb-2 flag-hover">
+                    <img src="public/flags/ca.svg" alt="Canada flag" class="h-14 w-auto rounded-lg shadow-md mb-2 flag-hover" width="512" height="512" loading="lazy">
                     <span class="text-gray-600">Canada</span>
                 </div>
                 <div class="flex flex-col items-center">
-                    <img src="public/flags/uk.svg" alt="United Kingdom flag" class="h-14 w-auto rounded-lg shadow-md mb-2 flag-hover">
+                    <img src="public/flags/uk.svg" alt="United Kingdom flag" class="h-14 w-auto rounded-lg shadow-md mb-2 flag-hover" width="512" height="512" loading="lazy">
                     <span class="text-gray-600">United Kingdom</span>
                 </div>
                 <div class="flex flex-col items-center">
-                    <img src="public/flags/eu.svg" alt="European Union flag" class="h-14 w-auto rounded-lg shadow-md mb-2 flag-hover">
+                    <img src="public/flags/eu.svg" alt="European Union flag" class="h-14 w-auto rounded-lg shadow-md mb-2 flag-hover" width="512" height="512" loading="lazy">
                     <span class="text-gray-600">European Union</span>
                 </div>
                 <div class="flex flex-col items-center">
-                    <img src="public/flags/au.svg" alt="Australia flag" class="h-14 w-auto rounded-lg shadow-md mb-2 flag-hover">
+                    <img src="public/flags/au.svg" alt="Australia flag" class="h-14 w-auto rounded-lg shadow-md mb-2 flag-hover" width="512" height="512" loading="lazy">
                     <span class="text-gray-600">Australia</span>
                 </div>
             </div>
@@ -281,63 +273,87 @@
         <!-- Useful Links Section -->
         <section id="useful-links" class="mb-20 text-center">
             <h2 class="text-2xl font-semibold text-blue-800 mb-6">Useful Links</h2>
-            <div class="flex flex-wrap justify-center items-stretch gap-4">
-                <a href="https://digwebinterface.com/" target="_blank" rel="noopener" class="block bg-white p-4 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 w-full sm:w-1/2 md:w-1/3 lg:w-1/4 square-hover">
-                    <h3 class="font-medium text-blue-600 mb-1">DigWebInterface</h3>
-                    <p class="text-gray-600 text-xs">A web-based DNS lookup tool.</p>
-                </a>
-                <a href="https://centralops.net/co/" target="_blank" rel="noopener" class="block bg-white p-4 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 w-full sm:w-1/2 md:w-1/3 lg:w-1/4 square-hover">
-                    <h3 class="font-medium text-blue-600 mb-1">CentralOPs.com</h3>
-                    <p class="text-gray-600 text-xs">Another great DNS lookup tool.</p>
-                </a>
-                <a href="https://mxtoolbox.com/" target="_blank" rel="noopener" class="block bg-white p-4 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 w-full sm:w-1/2 md:w-1/3 lg:w-1/4 square-hover">
-                    <h3 class="font-medium text-blue-600 mb-1">MXToolBox.com</h3>
-                    <p class="text-gray-600 text-xs">Easily check the MX settings.</p>
-                </a>
-                <a href="https://dnschecker.org/" target="_blank" rel="noopener" class="block bg-white p-4 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 w-full sm:w-1/2 md:w-1/3 lg:w-1/4 square-hover">
-                    <h3 class="font-medium text-blue-600 mb-1">DNS Checker</h3>
-                    <p class="text-gray-600 text-xs">Check DNS propagation from multiple locations.</p>
-                </a>
-                <a href="https://www.whatismyip.com/" target="_blank" rel="noopener" class="block bg-white p-4 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 w-full sm:w-1/2 md:w-1/3 lg:w-1/4 square-hover">
-                    <h3 class="font-medium text-blue-600 mb-1">WhatIsMyIP.com</h3>
-                    <p class="text-gray-600 text-xs">Quickly find your public IP address.</p>
-                </a>
-                <a href="https://ipinfo.io/ip" target="_blank" rel="noopener" class="block bg-white p-4 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 w-full sm:w-1/2 md:w-1/3 lg:w-1/4 square-hover">
-                    <h3 class="font-medium text-blue-600 mb-1">IPInfo.io</h3>
-                    <p class="text-gray-600 text-xs">Check your public IP.</p>
-                </a>
-                <a href="https://www.calculator.net/ip-subnet-calculator.html" target="_blank" rel="noopener" class="block bg-white p-4 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 w-full sm:w-1/2 md:w-1/3 lg:w-1/4 square-hover">
-                    <h3 class="font-medium text-blue-600 mb-1">Calculator.net</h3>
-                    <p class="text-gray-600 text-xs">IP Subnet Calculator.</p>
-                </a>
-                <a href="https://dmarcian.com/xml-to-human-converter/" target="_blank" rel="noopener" class="block bg-white p-4 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 w-full sm:w-1/2 md:w-1/3 lg:w-1/4 square-hover">
-                    <h3 class="font-medium text-blue-600 mb-1">DMARCian.com</h3>
-                    <p class="text-gray-600 text-xs">DMARC report analyzer.</p>
-                </a>
-                <a href="https://zohomail.tools/#dmarc" target="_blank" rel="noopener" class="block bg-white p-4 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 w-full sm:w-1/2 md:w-1/3 lg:w-1/4 square-hover">
-                    <h3 class="font-medium text-blue-600 mb-1">ZohoMail.com</h3>
-                    <p class="text-gray-600 text-xs">DMARC report analyzer.</p>
-                </a>
-                <a href="https://www.learndmarc.com/" target="_blank" rel="noopener" class="block bg-white p-4 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 w-full sm:w-1/2 md:w-1/3 lg:w-1/4 square-hover">
-                    <h3 class="font-medium text-blue-600 mb-1">LearnDMARC.com</h3>
-                    <p class="text-gray-600 text-xs">Test your DMARC records.</p>
-                </a>
-                <a href="https://www.ssllabs.com/ssltest/index.html" target="_blank" rel="noopener" class="block bg-white p-4 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 w-full sm:w-1/2 md:w-1/3 lg:w-1/4 square-hover">
-                    <h3 class="font-medium text-blue-600 mb-1">SSLLabs.com</h3>
-                    <p class="text-gray-600 text-xs">Test the security of your site.</p>
-                </a>
-                <a href="https://www.sslchecker.com/sslchecker" target="_blank" rel="noopener" class="block bg-white p-4 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 w-full sm:w-1/2 md:w-1/3 lg:w-1/4 square-hover">
-                    <h3 class="font-medium text-blue-600 mb-1">SSLChecker.com</h3>
-                    <p class="text-gray-600 text-xs">Check the SSL certificate validity of a website.</p>
-                </a>
-            </div>
+            <ul class="useful-links-list flex flex-wrap justify-center items-stretch gap-4">
+                <li class="useful-links-item w-full sm:w-1/2 md:w-1/3 lg:w-1/4">
+                    <a href="https://digwebinterface.com/" target="_blank" rel="noopener" class="block bg-white p-4 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 square-hover">
+                        <h3 class="font-medium text-blue-600 mb-1">DigWebInterface</h3>
+                        <p class="text-gray-600 text-xs">A web-based DNS lookup tool.</p>
+                    </a>
+                </li>
+                <li class="useful-links-item w-full sm:w-1/2 md:w-1/3 lg:w-1/4">
+                    <a href="https://centralops.net/co/" target="_blank" rel="noopener" class="block bg-white p-4 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 square-hover">
+                        <h3 class="font-medium text-blue-600 mb-1">CentralOPs.com</h3>
+                        <p class="text-gray-600 text-xs">Another great DNS lookup tool.</p>
+                    </a>
+                </li>
+                <li class="useful-links-item w-full sm:w-1/2 md:w-1/3 lg:w-1/4">
+                    <a href="https://mxtoolbox.com/" target="_blank" rel="noopener" class="block bg-white p-4 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 square-hover">
+                        <h3 class="font-medium text-blue-600 mb-1">MXToolBox.com</h3>
+                        <p class="text-gray-600 text-xs">Easily check the MX settings.</p>
+                    </a>
+                </li>
+                <li class="useful-links-item w-full sm:w-1/2 md:w-1/3 lg:w-1/4">
+                    <a href="https://dnschecker.org/" target="_blank" rel="noopener" class="block bg-white p-4 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 square-hover">
+                        <h3 class="font-medium text-blue-600 mb-1">DNS Checker</h3>
+                        <p class="text-gray-600 text-xs">Check DNS propagation from multiple locations.</p>
+                    </a>
+                </li>
+                <li class="useful-links-item w-full sm:w-1/2 md:w-1/3 lg:w-1/4">
+                    <a href="https://www.whatismyip.com/" target="_blank" rel="noopener" class="block bg-white p-4 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 square-hover">
+                        <h3 class="font-medium text-blue-600 mb-1">WhatIsMyIP.com</h3>
+                        <p class="text-gray-600 text-xs">Quickly find your public IP address.</p>
+                    </a>
+                </li>
+                <li class="useful-links-item w-full sm:w-1/2 md:w-1/3 lg:w-1/4">
+                    <a href="https://ipinfo.io/ip" target="_blank" rel="noopener" class="block bg-white p-4 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 square-hover">
+                        <h3 class="font-medium text-blue-600 mb-1">IPInfo.io</h3>
+                        <p class="text-gray-600 text-xs">Check your public IP.</p>
+                    </a>
+                </li>
+                <li class="useful-links-item w-full sm:w-1/2 md:w-1/3 lg:w-1/4">
+                    <a href="https://www.calculator.net/ip-subnet-calculator.html" target="_blank" rel="noopener" class="block bg-white p-4 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 square-hover">
+                        <h3 class="font-medium text-blue-600 mb-1">Calculator.net</h3>
+                        <p class="text-gray-600 text-xs">IP Subnet Calculator.</p>
+                    </a>
+                </li>
+                <li class="useful-links-item w-full sm:w-1/2 md:w-1/3 lg:w-1/4">
+                    <a href="https://dmarcian.com/xml-to-human-converter/" target="_blank" rel="noopener" class="block bg-white p-4 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 square-hover">
+                        <h3 class="font-medium text-blue-600 mb-1">DMARCian.com</h3>
+                        <p class="text-gray-600 text-xs">DMARC report analyzer.</p>
+                    </a>
+                </li>
+                <li class="useful-links-item w-full sm:w-1/2 md:w-1/3 lg:w-1/4">
+                    <a href="https://zohomail.tools/#dmarc" target="_blank" rel="noopener" class="block bg-white p-4 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 square-hover">
+                        <h3 class="font-medium text-blue-600 mb-1">ZohoMail.com</h3>
+                        <p class="text-gray-600 text-xs">DMARC report analyzer.</p>
+                    </a>
+                </li>
+                <li class="useful-links-item w-full sm:w-1/2 md:w-1/3 lg:w-1/4">
+                    <a href="https://www.learndmarc.com/" target="_blank" rel="noopener" class="block bg-white p-4 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 square-hover">
+                        <h3 class="font-medium text-blue-600 mb-1">LearnDMARC.com</h3>
+                        <p class="text-gray-600 text-xs">Test your DMARC records.</p>
+                    </a>
+                </li>
+                <li class="useful-links-item w-full sm:w-1/2 md:w-1/3 lg:w-1/4">
+                    <a href="https://www.ssllabs.com/ssltest/index.html" target="_blank" rel="noopener" class="block bg-white p-4 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 square-hover">
+                        <h3 class="font-medium text-blue-600 mb-1">SSLLabs.com</h3>
+                        <p class="text-gray-600 text-xs">Test the security of your site.</p>
+                    </a>
+                </li>
+                <li class="useful-links-item w-full sm:w-1/2 md:w-1/3 lg:w-1/4">
+                    <a href="https://www.sslchecker.com/sslchecker" target="_blank" rel="noopener" class="block bg-white p-4 rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 square-hover">
+                        <h3 class="font-medium text-blue-600 mb-1">SSLChecker.com</h3>
+                        <p class="text-gray-600 text-xs">Check the SSL certificate validity of a website.</p>
+                    </a>
+                </li>
+            </ul>
         </section>
 
     </main>
 
     <!-- Footer -->
     <footer class="bg-gray-800 text-white py-8 px-6 text-center">
-        <p class="text-sm">&copy; 2025 MoliseIT - Your Cloud Migration Partner. All rights reserved.</p>
+        <p class="footer-text text-sm">&copy; 2025 MoliseIT - Your Cloud Migration Partner. All rights reserved.</p>
     </footer>
 
 </body>

--- a/public/css/tailwind.min.css
+++ b/public/css/tailwind.min.css
@@ -1,0 +1,342 @@
+/* Precompiled utility bundle tailored for the landing page */
+:root {
+  color-scheme: only light;
+  --color-blue-600: #2563eb;
+  --color-blue-700: #1d4ed8;
+  --color-blue-800: #1e40af;
+  --color-blue-900: #1e3a8a;
+  --color-gray-50: #f9fafb;
+  --color-gray-500: #6b7280;
+  --color-gray-600: #4b5563;
+  --color-gray-700: #374151;
+  --color-gray-800: #1f2937;
+  --color-white: #ffffff;
+  --shadow-md: 0 4px 6px -1px rgba(15, 23, 42, 0.15), 0 2px 4px -2px rgba(15, 23, 42, 0.1);
+  --shadow-lg: 0 25px 50px -12px rgba(30, 64, 175, 0.35);
+}
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+html {
+  line-height: 1.5;
+  -webkit-text-size-adjust: 100%;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+body {
+  margin: 0;
+  background-color: var(--color-gray-50);
+  color: var(--color-gray-800);
+}
+main {
+  display: block;
+}
+img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+a {
+  color: inherit;
+  text-decoration: none;
+}
+a:focus-visible {
+  outline: 2px solid var(--color-blue-600);
+  outline-offset: 2px;
+}
+
+.skip-link {
+  position: absolute;
+  left: 1rem;
+  top: 1rem;
+  background-color: var(--color-white);
+  color: var(--color-blue-800);
+  padding: 0.5rem 1rem;
+  border-radius: 9999px;
+  box-shadow: var(--shadow-md);
+  transform: translateY(-200%);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  z-index: 50;
+}
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+.container {
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 1rem;
+  padding-right: 1rem;
+  max-width: 100%;
+}
+@media (min-width: 640px) {
+  .container {
+    max-width: 640px;
+  }
+}
+@media (min-width: 768px) {
+  .container {
+    max-width: 768px;
+  }
+}
+@media (min-width: 1024px) {
+  .container {
+    max-width: 1024px;
+  }
+}
+@media (min-width: 1280px) {
+  .container {
+    max-width: 1280px;
+  }
+}
+
+.relative { position: relative; }
+.absolute { position: absolute; }
+.top-4 { top: 1rem; }
+.left-4 { left: 1rem; }
+.right-4 { right: 1rem; }
+
+.block { display: block; }
+.inline-block { display: inline-block; }
+.flex { display: flex; }
+.grid { display: grid; }
+.flex-col { flex-direction: column; }
+.flex-wrap { flex-wrap: wrap; }
+.items-center { align-items: center; }
+.items-stretch { align-items: stretch; }
+.justify-center { justify-content: center; }
+.text-center { text-align: center; }
+
+.gap-3 { gap: 0.75rem; }
+.gap-4 { gap: 1rem; }
+.gap-6 { gap: 1.5rem; }
+.gap-8 { gap: 2rem; }
+
+.py-12 { padding-top: 3rem; padding-bottom: 3rem; }
+.py-16 { padding-top: 4rem; padding-bottom: 4rem; }
+.py-8 { padding-top: 2rem; padding-bottom: 2rem; }
+.py-4 { padding-top: 1rem; padding-bottom: 1rem; }
+.py-3 { padding-top: 0.75rem; padding-bottom: 0.75rem; }
+.p-2 { padding: 0.5rem; }
+.p-4 { padding: 1rem; }
+.p-5 { padding: 1.25rem; }
+.p-6 { padding: 1.5rem; }
+.p-8 { padding: 2rem; }
+.px-6 { padding-left: 1.5rem; padding-right: 1.5rem; }
+.px-8 { padding-left: 2rem; padding-right: 2rem; }
+.px-10 { padding-left: 2.5rem; padding-right: 2.5rem; }
+
+.mx-auto { margin-left: auto; margin-right: auto; }
+.mt-4 { margin-top: 1rem; }
+.mt-16 { margin-top: 4rem; }
+.mb-1 { margin-bottom: 0.25rem; }
+.mb-2 { margin-bottom: 0.5rem; }
+.mb-3 { margin-bottom: 0.75rem; }
+.mb-4 { margin-bottom: 1rem; }
+.mb-6 { margin-bottom: 1.5rem; }
+.mb-8 { margin-bottom: 2rem; }
+.mb-12 { margin-bottom: 3rem; }
+.mb-20 { margin-bottom: 5rem; }
+
+.w-full { width: 100%; }
+.w-auto { width: auto; }
+.w-6 { width: 1.5rem; }
+.w-12 { width: 3rem; }
+.h-6 { height: 1.5rem; }
+.h-12 { height: 3rem; }
+.h-14 { height: 3.5rem; }
+.h-16 { height: 4rem; }
+.h-20 { height: 5rem; }
+
+.max-w-2xl { max-width: 42rem; }
+.max-w-4xl { max-width: 56rem; }
+
+.rounded-lg { border-radius: 0.5rem; }
+.rounded-xl { border-radius: 0.75rem; }
+.rounded-2xl { border-radius: 1rem; }
+.rounded-3xl { border-radius: 1.5rem; }
+.rounded-full { border-radius: 9999px; }
+
+.border { border-width: 1px; border-style: solid; border-color: #e5e7eb; }
+.border-blue-100 { border-color: #dbeafe; }
+
+.shadow-md { box-shadow: var(--shadow-md); }
+.shadow-lg { box-shadow: var(--shadow-lg); }
+
+.text-xs { font-size: 0.75rem; line-height: 1rem; }
+.text-sm { font-size: 0.875rem; line-height: 1.25rem; }
+.text-lg { font-size: 1.125rem; line-height: 1.75rem; }
+.text-2xl { font-size: 1.5rem; line-height: 2rem; }
+.text-3xl { font-size: 1.875rem; line-height: 2.25rem; }
+.text-4xl { font-size: 2.25rem; line-height: 2.5rem; }
+.font-light { font-weight: 300; }
+.font-medium { font-weight: 500; }
+.font-semibold { font-weight: 600; }
+.font-bold { font-weight: 700; }
+.leading-tight { line-height: 1.25; }
+.leading-relaxed { line-height: 1.625; }
+
+.text-white { color: var(--color-white); }
+.text-blue-600 { color: var(--color-blue-600); }
+.text-blue-700 { color: var(--color-blue-700); }
+.text-blue-800 { color: var(--color-blue-800); }
+.text-blue-900 { color: var(--color-blue-900); }
+.text-gray-500 { color: var(--color-gray-500); }
+.text-gray-600 { color: var(--color-gray-600); }
+.text-gray-700 { color: var(--color-gray-700); }
+.text-gray-800 { color: var(--color-gray-800); }
+
+.bg-gray-50 { background-color: var(--color-gray-50); }
+.bg-gray-800 { background-color: var(--color-gray-800); }
+.bg-white { background-color: var(--color-white); }
+.bg-white\/20 { background-color: rgba(255, 255, 255, 0.2); }
+.bg-blue-100 { background-color: #dbeafe; }
+.bg-blue-600 { background-color: var(--color-blue-600); }
+.bg-gradient-to-r {
+  background-image: linear-gradient(to right, var(--tw-gradient-from, transparent), var(--tw-gradient-to, transparent));
+}
+.from-blue-600 {
+  --tw-gradient-from: var(--color-blue-600);
+  --tw-gradient-to: rgba(37, 99, 235, 0);
+}
+.to-blue-800 {
+  --tw-gradient-to: var(--color-blue-800);
+}
+
+.transition { transition-property: all; transition-duration: 150ms; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
+.transition-colors { transition-property: color, background-color, border-color, fill, stroke; transition-duration: 150ms; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
+.transition-shadow { transition-property: box-shadow; transition-duration: 150ms; transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1); }
+.duration-300 { transition-duration: 300ms; }
+
+.hover\:bg-blue-700:hover { background-color: var(--color-blue-700); }
+.hover\:bg-gray-100:hover { background-color: #f3f4f6; }
+.hover\:bg-white\/30:hover { background-color: rgba(255, 255, 255, 0.3); }
+.hover\:shadow-lg:hover { box-shadow: var(--shadow-lg); }
+
+.text-white a { color: inherit; }
+
+.logo-hover {
+  transition: transform 0.35s ease, filter 0.35s ease;
+}
+.logo-hover:hover {
+  transform: translateY(-4px) scale(1.06) rotate(-2deg);
+  filter: drop-shadow(0 12px 24px rgba(30, 64, 175, 0.35));
+}
+.square-hover {
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
+}
+.square-hover:hover {
+  transform: translateY(-6px) scale(1.03);
+  box-shadow: 0 24px 45px -20px rgba(30, 64, 175, 0.45);
+}
+.flag-hover {
+  transition: transform 0.35s ease, box-shadow 0.35s ease;
+}
+.flag-hover:hover {
+  transform: translateY(-6px) scale(1.05) rotate(1.5deg);
+  box-shadow: 0 16px 32px -18px rgba(15, 23, 42, 0.55);
+}
+
+.section-heading {
+  font-weight: 600;
+  color: #1a202c;
+}
+
+.header-nav {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 2rem;
+}
+.header-nav ul {
+  display: flex;
+  gap: 1.5rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.header-nav a {
+  font-weight: 500;
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.85);
+  position: relative;
+  padding-bottom: 0.25rem;
+}
+.header-nav a::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  height: 2px;
+  width: 100%;
+  background-color: rgba(255, 255, 255, 0.0);
+  transition: background-color 0.2s ease;
+}
+.header-nav a:hover::after,
+.header-nav a:focus-visible::after {
+  background-color: rgba(255, 255, 255, 0.9);
+}
+
+@media (min-width: 640px) {
+  .sm\:grid-cols-2 { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .sm\:left-6 { left: 1.5rem; }
+  .sm\:right-6 { right: 1.5rem; }
+  .sm\:top-6 { top: 1.5rem; }
+  .sm\:px-12 { padding-left: 3rem; padding-right: 3rem; }
+  .sm\:p-12 { padding: 3rem; }
+  .sm\:p-10 { padding: 2.5rem; }
+  .sm\:text-3xl { font-size: 1.875rem; line-height: 2.25rem; }
+  .sm\:text-4xl { font-size: 2.25rem; line-height: 2.5rem; }
+  .sm\:text-5xl { font-size: 3rem; line-height: 1; }
+  .sm\:text-xl { font-size: 1.25rem; line-height: 1.75rem; }
+  .sm\:w-1\/2 { width: 50%; }
+}
+@media (min-width: 768px) {
+  .md\:grid-cols-3 { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .md\:px-24 { padding-left: 6rem; padding-right: 6rem; }
+  .md\:p-16 { padding: 4rem; }
+  .md\:text-6xl { font-size: 3.75rem; line-height: 1; }
+  .md\:w-1\/3 { width: 33.333333%; }
+}
+@media (min-width: 1024px) {
+  .lg\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+  .lg\:w-1\/4 { width: 25%; }
+}
+@media (min-width: 1280px) {
+  .xl\:grid-cols-4 { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+  .xl\:grid-cols-5 { grid-template-columns: repeat(5, minmax(0, 1fr)); }
+}
+
+.footer-text {
+  font-size: 0.875rem;
+}
+
+@media (max-width: 639px) {
+  .header-nav {
+    justify-content: center;
+    margin-top: 3.5rem;
+  }
+  .header-nav ul {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+}
+
+.useful-links-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.useful-links-item {
+  display: flex;
+}
+
+.useful-links-item > a {
+  flex: 1 1 auto;
+}
+
+.footer-text {
+  margin: 0;
+}


### PR DESCRIPTION
## Summary
- replace the Tailwind CDN script with a locally hosted stylesheet that includes SRI metadata and consolidated utility rules
- add a skip link, landmark navigation, and intrinsic image sizing with lazy-loading throughout the landing page
- expand the head section with canonical, Open Graph, and Twitter metadata and refactor the useful links grid into a semantic list

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d36a715510832f89892499ca9b2cba